### PR TITLE
Retain config and some code cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.txt
 *.log
 config.yml
+desktop.ini
 
 .vscode/*
 env/*

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ optional arguments:
   -mP MQTTPASSWORD, --mqttpassword MQTTPASSWORD
                         Mqtt Password
   -s, --discover        Discover devices
-  -d, --debug           set logging level to debug
-  -v, --version         Print Verions
+  -d, --debug           Set logging level to debug
+  -v, --version         Print Versions
   -dir DATA_DIR, --data_dir DATA_DIR
                         Data Folder -- Default to folder script is located
   -c CONFIG, --config CONFIG
@@ -72,7 +72,7 @@ optional arguments:
 
 example: Run in background
 ./monitor.py -b
-run with full debugging (logs to ac_to_mqtt.log in folder where monitor.py is located)
+run with full debugging (logs to log/out.log )
 ./monitor.py -d
 
 Dump all discovered devices so one can copy paste

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   * Rinnai  --> Tested and working .. autodiscovery name seems to be buggy
   * Kenwood --> In Testing
   * Tornado X (2019 and up) --> Tested and working
-  * AUX ASW-H09A4/DE-R1DI ("non original" broadlink module) --> Tested and working
+  * AUX ASW-H09A4/DE-R1DI (Broadlink module) --> Tested and working
   * In theory any Broadlink devtype == 0x4E2a (20010) using the AC Freedom APP
 
 #### Installation: 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   * Rinnai  --> Tested and working .. autodiscovery name seems to be buggy
   * Kenwood --> In Testing
   * Tornado X (2019 and up) --> Tested and working
-  * AUX ASW-H09A4/DE-R1DI --> Tested and working
+  * AUX ASW-H09A4/DE-R1DI ("non original" broadlink module) --> Tested and working
   * In theory any Broadlink devtype == 0x4E2a (20010) using the AC Freedom APP
 
 #### Installation: 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ to set values just publish to /aircon/mac_address/option/value/set  new_value  :
 ```
 mqtt:
   discovery: true
-  discovery_prefix: homeassistant
+  auto_discovery_topic: homeassistant
   
 ```
 

--- a/broadlink_ac_mqtt/AcToMqtt.py
+++ b/broadlink_ac_mqtt/AcToMqtt.py
@@ -183,12 +183,15 @@ class AcToMqtt:
 		if devices_array == {}:
 			print ("something went wrong, no devices found")
 			sys.exit()	
-		
+		if(self.config["mqtt_retain"]):
+			retain = self.config["mqtt_retain"]
+		else: 
+			retain = False	
 		for key in devices_array:
 			device = devices_array[key]			
 			topic = self.config["mqtt_auto_discovery_topic"]+"/climate/"+key+"/config"
 			##Publish						
-			self._publish(topic,json.dumps(device))			
+			self._publish(topic,json.dumps(device), retain = retain)			
 				
 	def publish_mqtt_info(self,status):	
 		 
@@ -231,8 +234,6 @@ class AcToMqtt:
 				
 				
 	def _publish(self,topic,value,retain=False,qos=0):
-		if(self.config["mqtt_retain"]):
-			retain = self.config["mqtt_retain"]
 		payload = value
 		logger.debug('publishing on topic "%s", data "%s"' % (topic, payload))			
 		pubResult = self._mqtt.publish(topic, payload=payload, qos=qos, retain=retain)

--- a/broadlink_ac_mqtt/AcToMqtt.py
+++ b/broadlink_ac_mqtt/AcToMqtt.py
@@ -231,7 +231,8 @@ class AcToMqtt:
 				
 				
 	def _publish(self,topic,value,retain=False,qos=0):
-		
+		if(self.config["mqtt_retain"]):
+			retain = self.config["mqtt_retain"]
 		payload = value
 		logger.debug('publishing on topic "%s", data "%s"' % (topic, payload))			
 		pubResult = self._mqtt.publish(topic, payload=payload, qos=qos, retain=retain)
@@ -248,7 +249,7 @@ class AcToMqtt:
 		
 		
 		##Set last will and testament
-		self._mqtt.will_set("/aircon/LWT","offline",True)
+		self._mqtt.will_set(self.config["mqtt_topic_prefix"]+"LWT","offline",True)
 		
 		##Auth		
 		if self.config["mqtt_user"] and self.config["mqtt_password"]:			
@@ -274,7 +275,7 @@ class AcToMqtt:
 	def _on_mqtt_log(self,client, userdata, level, buf):
 			
 		if level == mqtt.MQTT_LOG_ERR:
-			logger.debug("Mqtt log" + buf)
+			logger.debug("Mqtt log: " + buf)
 		
 	def _mqtt_on_subscribe(self,client, userdata, mid, granted_qos):
 		logger.debug("Mqtt Subscribed")
@@ -322,7 +323,7 @@ class AcToMqtt:
 				if status :
 					self.publish_mqtt_info(status)
 			else:
-				logger.debug("Switch on has invalid value, values is on/off received %s",value)
+				logger.debug("Switch has invalid value, values is on/off received %s",value)
 				return
 				
 		elif function == "mode":
@@ -332,7 +333,7 @@ class AcToMqtt:
 				self.publish_mqtt_info(status)
 				
 			else:
-				logger.debug("Mode on has invalid value %s",value)
+				logger.debug("Mode has invalid value %s",value)
 				return
 		elif function == "fanspeed":
 			
@@ -341,7 +342,7 @@ class AcToMqtt:
 				self.publish_mqtt_info(status)
 				
 			else:
-				logger.debug("Fanspeed on has invalid value %s",value)
+				logger.debug("Fanspeed has invalid value %s",value)
 				return
 				
 		elif function == "fanspeed_homeassistant":
@@ -351,7 +352,7 @@ class AcToMqtt:
 				self.publish_mqtt_info(status)
 				
 			else:
-				logger.debug("Fanspeed on has invalid value %s",value)
+				logger.debug("Fanspeed_homeassistant has invalid value %s",value)
 				return
 				
 		elif function == "mode_homekit":
@@ -361,7 +362,7 @@ class AcToMqtt:
 				self.publish_mqtt_info(status)
 				
 			else:
-				logger.debug("Fanspeed on has invalid value %s",value)
+				logger.debug("Mode_homekit has invalid value %s",value)
 				return
 		elif function == "mode_homeassistant":
 			
@@ -370,7 +371,7 @@ class AcToMqtt:
 				self.publish_mqtt_info(status)
 				
 			else:
-				logger.debug("Fanspeed on has invalid value %s",value)
+				logger.debug("Mode_homeassistant has invalid value %s",value)
 				return		
 		else:
 			logger.debug("No function match")

--- a/monitor.py
+++ b/monitor.py
@@ -12,7 +12,7 @@ import signal
 
 logger = logging.getLogger(__name__)
 AC = None
-softwareversion = "1.0.13a"
+softwareversion = "1.0.14"
 
 
 pid = str(os.getpid())
@@ -75,7 +75,7 @@ def read_config(config_file_path):
 	config["mqtt_client_id"] = config_file["mqtt"]["client_id"] if config_file["mqtt"]["client_id"] else 'broadlink_to_mqtt-'+str(time.time())
 	config["mqtt_topic_prefix"] = config_file["mqtt"]["topic_prefix"]
 	config["mqtt_auto_discovery_topic"] = config_file["mqtt"]["auto_discovery_topic"]
-	
+	config["mqtt_retain"] = config_file["mqtt"]["retain"]
 	
 	if config["mqtt_topic_prefix"] and config["mqtt_topic_prefix"].endswith("/") == False:
 		config["mqtt_topic_prefix"] = config["mqtt_topic_prefix"] + "/"

--- a/monitor.py
+++ b/monitor.py
@@ -75,7 +75,8 @@ def read_config(config_file_path):
 	config["mqtt_client_id"] = config_file["mqtt"]["client_id"] if config_file["mqtt"]["client_id"] else 'broadlink_to_mqtt-'+str(time.time())
 	config["mqtt_topic_prefix"] = config_file["mqtt"]["topic_prefix"]
 	config["mqtt_auto_discovery_topic"] = config_file["mqtt"]["auto_discovery_topic"]
-	config["mqtt_retain"] = config_file["mqtt"]["retain"]
+	config["mqtt_retain"] = config_file["mqtt"]["retain"] if "retain" in config_file["mqtt"] else False
+	
 	
 	if config["mqtt_topic_prefix"] and config["mqtt_topic_prefix"].endswith("/") == False:
 		config["mqtt_topic_prefix"] = config["mqtt_topic_prefix"] + "/"

--- a/settings/config_sample.yml
+++ b/settings/config_sample.yml
@@ -11,6 +11,8 @@ mqtt:
     passwd: karman
     topic_prefix: /aircon
     auto_discovery_topic: homeassistant
+    retain: False
+    discovery: False
 
 ##Devices
 devices:


### PR DESCRIPTION
1. Added "retain" config option. Usefull for home assistant autodiscovery (with ratain==false hass don't get autodiscovery message in some cases and need to restart broadling_ac_mqtt to send it again)
2. Debug messages, readme, config_sample cleanup\update