### PR TITLE
Fixed temperature step in MQTT discovery

### DIFF
--- a/broadlink_ac_mqtt/AcToMqtt.py
+++ b/broadlink_ac_mqtt/AcToMqtt.py
@@ -165,7 +165,7 @@ class AcToMqtt:
 				,"modes": ['off',"cool","heat","fan_only","dry"]
 				,"max_temp":32.0
 				,"min_temp":16.0
-				,"precision": 0.5
+				,"temp_step": 0.5
 				,"unique_id": device.status["macaddress"]
 				,"device" : {"ids":device.status["macaddress"],"name":str(name.decode("utf-8")),"model":'Aircon',"mf":"Broadlink","sw":broadlink.version}				
 				,"pl_avail":"online"


### PR DESCRIPTION
According to [documentation](https://www.home-assistant.io/docs/mqtt/discovery/#climate-control), there is no `precision` field in discovery message. I renamed it to `temp_step` as described